### PR TITLE
Add subcommand to upload files via API

### DIFF
--- a/flags.go
+++ b/flags.go
@@ -11,3 +11,66 @@ func newLogLevelFlag() *cli.IntFlag {
 		Value: 0,
 	}
 }
+
+func newURLFlag(dest *string) *cli.StringFlag {
+	return &cli.StringFlag{
+		Name: "url", EnvVars: envVars("URL"),
+		Usage:       "URL endpoint of the paperless instance.",
+		Required:    true,
+		Destination: dest,
+	}
+}
+
+func newTokenFlag(dest *string) *cli.StringFlag {
+	return &cli.StringFlag{
+		Name: "token", EnvVars: envVars("TOKEN"),
+		Usage:       "Password or Token of the paperless instance.",
+		Destination: dest,
+	}
+}
+
+func newUsernameFlag(dest *string) *cli.StringFlag {
+	return &cli.StringFlag{
+		Name: "username", EnvVars: envVars("USERNAME"),
+		Usage:       "username for BasicAuth of the paperless instance. Leave empty to use token authentication.",
+		Destination: dest,
+	}
+}
+
+func newCreatedAtFlag(dest *cli.Timestamp) *cli.TimestampFlag {
+	return &cli.TimestampFlag{
+		Name:        "created-at",
+		Usage:       `set the "created" date for all given files.`,
+		Layout:      "2006-01-02",
+		Destination: dest,
+	}
+}
+
+func newTitleFlag(dest *string) *cli.StringFlag {
+	return &cli.StringFlag{
+		Name:        "title",
+		Usage:       "set the document title for all given files.",
+		Destination: dest,
+	}
+}
+func newCorrespondentFlag(dest *string) *cli.StringFlag {
+	return &cli.StringFlag{
+		Name:        "correspondent",
+		Usage:       "set the correspondent for all given files.",
+		Destination: dest,
+	}
+}
+func newDocumentTypeFlag(dest *string) *cli.StringFlag {
+	return &cli.StringFlag{
+		Name:        "type",
+		Usage:       "set the document type for all given files.",
+		Destination: dest,
+	}
+}
+func newTagFlag(dest *cli.StringSlice) *cli.StringSliceFlag {
+	return &cli.StringSliceFlag{
+		Name:        "tag",
+		Usage:       "set the document tag(s) for all given files.",
+		Destination: dest,
+	}
+}

--- a/logger.go
+++ b/logger.go
@@ -10,6 +10,8 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
+var logger logr.Logger
+
 func init() {
 	// Remove `-v` short option from --version flag
 	cli.VersionFlag.(*cli.BoolFlag).Aliases = nil
@@ -33,13 +35,14 @@ func LogMetadata(c *cli.Context) error {
 }
 
 func setupLogging(c *cli.Context) error {
-	log := newPlogger()
-	c.Context = logr.NewContext(c.Context, log)
+	logger = newPlogger()
+	c.Context = logr.NewContext(c.Context, logger)
 	return nil
 }
 
 func newPlogger() logr.Logger {
 	sink := plogr.NewPtermSink()
 	sink.FallbackPrinter = &pterm.Debug
+	sink.ErrorPrinter.ShowLineNumber = false
 	return logr.New(sink)
 }

--- a/main.go
+++ b/main.go
@@ -25,7 +25,7 @@ func main() {
 	app := NewApp()
 	err := app.Run(os.Args)
 	if err != nil {
-		_, _ = fmt.Fprintf(os.Stderr, "%v\n", err)
+		logger.Error(err, "Fatal error")
 		os.Exit(1)
 	}
 }

--- a/pkg/paperless/client.go
+++ b/pkg/paperless/client.go
@@ -1,0 +1,32 @@
+package paperless
+
+import (
+	"net/http"
+)
+
+type Client struct {
+	URL        string
+	HttpClient *http.Client
+
+	username string
+	token    string
+}
+
+// NewClient creates a new PaperlessClient using the given URL and credentials.
+// If using token auth, `username` parameter can be left empty.
+func NewClient(url, username, passwordOrToken string) *Client {
+	return &Client{
+		URL:        url,
+		HttpClient: http.DefaultClient,
+		username:   username,
+		token:      passwordOrToken,
+	}
+}
+
+func (clt *Client) setAuth(req *http.Request) {
+	if clt.username == "" {
+		req.Header.Set("Authorization", "Token "+clt.token)
+	} else {
+		req.SetBasicAuth(clt.username, clt.token)
+	}
+}

--- a/pkg/paperless/upload.go
+++ b/pkg/paperless/upload.go
@@ -1,0 +1,102 @@
+package paperless
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/go-logr/logr"
+)
+
+type UploadParams struct {
+	Title         string
+	Created       time.Time
+	Correspondent string
+	DocumentType  string
+	Tags          []string
+}
+
+func (clt *Client) Upload(ctx context.Context, filePath string, params UploadParams) error {
+	req, err := clt.makeFileUploadRequest(ctx, filePath, params)
+	if err != nil {
+		return err
+	}
+
+	resp, err := clt.HttpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("request failed: %w", err)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	errMessage := string(body)
+	switch resp.StatusCode {
+	case http.StatusOK:
+		return nil
+	case http.StatusUnauthorized:
+		return fmt.Errorf("unauthorized")
+	default:
+		return fmt.Errorf("request failed with status code %d: %v", resp.StatusCode, errMessage)
+	}
+}
+
+func (clt *Client) makeFileUploadRequest(ctx context.Context, filePath string, params UploadParams) (*http.Request, error) {
+	log := logr.FromContextOrDiscard(ctx).WithValues("filePath", filePath)
+
+	log.V(1).Info("Reading file")
+	file, err := os.Open(filePath)
+	if err != nil {
+		return nil, fmt.Errorf("cannot read source file: %w", err)
+	}
+	defer file.Close()
+
+	log.V(1).Info("Preparing payload for file upload")
+	body := &bytes.Buffer{}
+	writer := multipart.NewWriter(body)
+	part, err := writer.CreateFormFile("document", filepath.Base(filePath))
+	if err != nil {
+		return nil, fmt.Errorf("cannot prepare file for upload: %w", err)
+	}
+	_, err = io.Copy(part, file)
+	if err != nil {
+		return nil, fmt.Errorf("cannot copy file to request: %w", err)
+	}
+
+	writeUploadFormFields(writer, params)
+
+	err = writer.Close()
+	if err != nil {
+		return nil, fmt.Errorf("cannot write form body: %w", err)
+	}
+
+	log.V(1).Info("Preparing request")
+	req, err := http.NewRequestWithContext(ctx, "POST", clt.URL+"/api/documents/post_document/", body)
+	if err != nil {
+		return nil, fmt.Errorf("cannot prepare request: %w", err)
+	}
+	clt.setAuth(req)
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+	return req, nil
+}
+
+func writeUploadFormFields(writer *multipart.Writer, params UploadParams) {
+	if !params.Created.IsZero() {
+		_ = writer.WriteField("created", params.Created.Format("2006-01-02"))
+	}
+	if v, f := params.Correspondent, "correspondent"; v != "" {
+		_ = writer.WriteField(f, v)
+	}
+	if v, f := params.Title, "title"; v != "" {
+		_ = writer.WriteField(f, v)
+	}
+	if v, f := params.DocumentType, "document_type"; v != "" {
+		_ = writer.WriteField(f, v)
+	}
+	for _, tag := range params.Tags {
+		_ = writer.WriteField("tags", tag) // we can specify multiple times
+	}
+}


### PR DESCRIPTION
## Summary

* Adds a subcommand, invocable with `paperless-cli upload [Files...)`

## Checklist

### For Code changes

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `kind:bug`, `kind:enhancement`, `kind:documentation`, `kind:change`, `kind:breaking`, `kind:dependency`
      as they show up in the changelog
- [x] Link this PR to related issues

<!--
Remove the section and checklist items that do not apply.
For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
