### PR TITLE
Add 'consume' subcommand

### DIFF
--- a/consume_command.go
+++ b/consume_command.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+
+	"github.com/ccremer/clustercode/pkg/consumer"
+	"github.com/ccremer/clustercode/pkg/paperless"
+	"github.com/go-logr/logr"
+	"github.com/urfave/cli/v2"
+)
+
+type ConsumeCommand struct {
+	cli.Command
+
+	PaperlessURL   string
+	PaperlessToken string
+	PaperlessUser  string
+
+	ConsumeDirName string
+}
+
+func newConsumeCommand() *ConsumeCommand {
+	c := &ConsumeCommand{}
+	c.Command = cli.Command{
+		Name:        "consume",
+		Description: "Consumes a local directory and uploads each file to Paperless instance. The files will be deleted once uploaded.",
+		Before:      LogMetadata,
+		Action:      c.Action,
+
+		Flags: []cli.Flag{
+			newURLFlag(&c.PaperlessURL),
+			newUsernameFlag(&c.PaperlessUser),
+			newTokenFlag(&c.PaperlessToken),
+			newConsumeDirFlag(&c.ConsumeDirName),
+		},
+	}
+	return c
+}
+
+func (c *ConsumeCommand) Action(ctx *cli.Context) error {
+	log := logr.FromContextOrDiscard(ctx.Context)
+	log.Info("Start consuming directory", "dir", c.ConsumeDirName)
+
+	clt := paperless.NewClient(c.PaperlessURL, c.PaperlessUser, c.PaperlessToken)
+	q := consumer.NewQueue[string]()
+	q.Subscribe(ctx.Context, func(fileName string) {
+		log.V(1).Info("Uploading file...", "file", fileName)
+		err := clt.Upload(ctx.Context, fileName, paperless.UploadParams{})
+		if err != nil {
+			log.Error(err, "Could not upload file")
+			return
+		}
+		if deleteErr := os.Remove(fileName); deleteErr != nil {
+			log.Error(err, "Could not delete file, this might be re-uploaded later again", "file", fileName)
+		}
+		log.Info("File uploaded", "file", fileName)
+	})
+
+	walkErr := filepath.WalkDir(c.ConsumeDirName, func(path string, entry fs.DirEntry, err error) error {
+		if path == c.ConsumeDirName {
+			return nil // same directory, not interesting
+		}
+		if entry.IsDir() {
+			return fs.SkipDir
+		}
+		if err != nil {
+			return fs.SkipDir
+		}
+		q.Put(path)
+		return nil
+	})
+	if walkErr != nil {
+		return fmt.Errorf("cannot walk consumption dir: %w", walkErr)
+	}
+
+	watchErr := consumer.StartWatchingDir(ctx.Context, c.ConsumeDirName, func(filePath string) {
+		q.Put(filePath)
+	})
+	if watchErr != nil {
+		return fmt.Errorf("cannot watch consumption dir: %w", watchErr)
+	}
+	<-make(chan struct{})
+	return nil
+}

--- a/flags.go
+++ b/flags.go
@@ -74,3 +74,12 @@ func newTagFlag(dest *cli.StringSlice) *cli.StringSliceFlag {
 		Destination: dest,
 	}
 }
+
+func newConsumeDirFlag(dest *string) *cli.StringFlag {
+	return &cli.StringFlag{
+		Name: "consume-dir", EnvVars: []string{"CONSUME_DIR"},
+		Usage:       "the directory name which to consume files.",
+		Required:    true,
+		Destination: dest,
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	atomicgo.dev/keyboard v0.2.8 // indirect
 	github.com/containerd/console v1.0.3 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.2 // indirect
+	github.com/fsnotify/fsnotify v1.6.0 // indirect
 	github.com/gookit/color v1.5.2 // indirect
 	github.com/lithammer/fuzzysearch v1.1.5 // indirect
 	github.com/mattn/go-runewidth v0.0.14 // indirect
@@ -21,7 +22,7 @@ require (
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/xo/terminfo v0.0.0-20210125001918-ca9a967f8778 // indirect
 	github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673 // indirect
-	golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f // indirect
+	golang.org/x/sys v0.0.0-20220908164124-27713097b956 // indirect
 	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 // indirect
 	golang.org/x/text v0.4.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -22,6 +22,8 @@ github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46t
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/fsnotify/fsnotify v1.6.0 h1:n+5WquG0fcWoWp6xPWfHdbskMCQaFnG6PfBrh1Ky4HY=
+github.com/fsnotify/fsnotify v1.6.0/go.mod h1:sl3t1tCWJFWoRz9R8WJCbQihKKwmorjAbSClcnxKAGw=
 github.com/go-logr/logr v1.2.3 h1:2DntVwHkVopvECVRSlL5PSo9eG+cAkDCuckLubN+rq0=
 github.com/go-logr/logr v1.2.3/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/gookit/color v1.4.2/go.mod h1:fqRyamkC1W8uxl+lxCQxOT09l/vYfZ+QeiX3rKQHCoQ=
@@ -80,6 +82,8 @@ golang.org/x/sys v0.0.0-20211013075003-97ac67df715c/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220319134239-a9b59b0215f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f h1:v4INt8xihDGvnrfjMDVXGxw9wrfxYyCjk0KbXjhR55s=
 golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220908164124-27713097b956 h1:XeJjHH1KiLpKGb6lvMiksZ9l0fVUh+AmGcm0nOMEBOY=
+golang.org/x/sys v0.0.0-20220908164124-27713097b956/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20210220032956-6a3ed077a48d/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210615171337-6886f2dfbf5b/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 h1:JGgROgKl9N8DuW20oFS5gxc+lE67/N3FcwmBPMe7ArY=

--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/pterm/pterm"
 	"github.com/urfave/cli/v2"
 )
 
@@ -25,7 +26,7 @@ func main() {
 	app := NewApp()
 	err := app.Run(os.Args)
 	if err != nil {
-		logger.Error(err, "Fatal error")
+		pterm.Error.Println(err.Error())
 		os.Exit(1)
 	}
 }
@@ -42,6 +43,7 @@ func NewApp() *cli.App {
 		},
 		Commands: []*cli.Command{
 			&newUploadCommand().Command,
+			&newConsumeCommand().Command,
 		},
 	}
 	return app

--- a/pkg/consumer/notify.go
+++ b/pkg/consumer/notify.go
@@ -1,0 +1,71 @@
+package consumer
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"sync"
+	"time"
+
+	"github.com/fsnotify/fsnotify"
+	"github.com/go-logr/logr"
+)
+
+func StartWatchingDir(ctx context.Context, dir string, callback func(filePath string)) error {
+	log := logr.FromContextOrDiscard(ctx)
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		return err
+	}
+
+	go func() {
+		waitFor := 1 * time.Second
+
+		// Keep track of the timers, as [path]timer.
+		timers := sync.Map{}
+
+		for {
+			select {
+			case <-ctx.Done():
+				log.V(1).Info("Stopping watcher")
+				break
+			case err, ok := <-watcher.Errors:
+				if !ok {
+					return
+				}
+				log.Error(err, "")
+			case e, ok := <-watcher.Events:
+				if !ok {
+					return
+				}
+
+				// We just want to watch for file creation, so ignore everything outside Create and Write.
+				if !e.Has(fsnotify.Create) && !e.Has(fsnotify.Write) {
+					continue
+				}
+				log.V(2).Info("New Event", "name", e.Name, "op", e.Op)
+
+				// Get timer.
+				t, exists := timers.Load(e.Name)
+
+				if !exists {
+					t = time.AfterFunc(math.MaxInt64, func() {
+						log.V(2).Info("Deleted timer", "name", e.Name)
+						timers.Delete(e.Name)
+						callback(e.Name)
+					})
+					t.(*time.Timer).Stop()
+					timers.Store(e.Name, t)
+				}
+				// Reset the timer for this path, so it will start from 100ms again.
+				t.(*time.Timer).Reset(waitFor)
+			}
+		}
+	}()
+	err = watcher.Add(dir)
+	if err != nil {
+		return fmt.Errorf("cannot start watcher: %w", err)
+	}
+	log.V(1).Info("Started watcher", "dir", dir)
+	return nil
+}

--- a/pkg/consumer/queue.go
+++ b/pkg/consumer/queue.go
@@ -1,0 +1,38 @@
+package consumer
+
+import (
+	"context"
+	"sync"
+)
+
+type Queue[T any] struct {
+	m  sync.Map
+	ch chan T
+}
+
+func NewQueue[T any]() *Queue[T] {
+	return &Queue[T]{
+		ch: make(chan T),
+	}
+}
+
+func (q *Queue[T]) Put(v T) {
+	_, loaded := q.m.LoadOrStore(v, nil)
+	if !loaded {
+		q.ch <- v
+	}
+}
+
+func (q *Queue[T]) Subscribe(ctx context.Context, fn func(v T)) {
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				break
+			case v := <-q.ch:
+				q.m.Delete(v)
+				fn(v)
+			}
+		}
+	}()
+}


### PR DESCRIPTION
## Summary

Introduces a new `consume` subcommand that watches a specific directory for filesystem changes and uploads every file.
This command is best run as a long-running process, e.g. a systemd service or docker container

## Checklist

### For Code changes

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `kind:bug`, `kind:enhancement`, `kind:documentation`, `kind:change`, `kind:breaking`, `kind:dependency`
      as they show up in the changelog
- [x] Link this PR to related issues

<!--
Remove the section and checklist items that do not apply.
For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
