### PR TITLE
Include systemd files in deb/rpm packages

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -30,6 +30,12 @@ nfpms:
     formats:
       - deb
       - rpm
+    contents:
+      - src: package/systemd.service
+        dst: /lib/systemd/system/paperless-consume.service
+      - src: package/systemd.env
+        dst: /etc/default/paperless-cli
+        type: config
 
 dockers:
   - goarch: amd64

--- a/package/systemd.env
+++ b/package/systemd.env
@@ -1,0 +1,19 @@
+### General
+
+## (Required) Target URL of the paperless-ngx instance.
+PAPERLESS_URL=
+
+## Username of the Paperless API user. Can be left empty if only using a Token.
+PAPERLESS_USERNAME=
+## (Required) Token or Password of the Paperless API user.
+PAPERLESS_TOKEN=
+
+### Consuming files and upload them
+
+## (Required) The directory path in which files are consumed (uploaded + deleted).
+CONSUME_DIR=
+
+### Misc
+
+## Logging level. Increased numbers are more verbose.
+# LOG_LEVEL=0

--- a/package/systemd.service
+++ b/package/systemd.service
@@ -1,0 +1,16 @@
+# This is a systemd unit file
+[Unit]
+Description=consumption service for paperless-ngx remote API
+Documentation=https://github.com/ccremer/paperless-cli
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+EnvironmentFile=-/etc/default/paperless-cli
+User=65534
+Group=0
+ExecStart=/usr/bin/paperless-cli consume
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Summary

Enables DEB and RPM packaging for running `consume` command as a systemd service.

Note: When installing the packages, the service still needs to be manually enabled with `systemctl enable paperless-consume`

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `kind:bug`, `kind:enhancement`, `kind:documentation`, `kind:change`, `kind:breaking`, `kind:dependency`
      as they show up in the changelog
- [x] Link this PR to related issues

<!--
Remove the section and checklist items that do not apply.
For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
