### PR TITLE
Fix required flags and usage printer

### DIFF
--- a/consume_command.go
+++ b/consume_command.go
@@ -27,8 +27,7 @@ func newConsumeCommand() *ConsumeCommand {
 	c.Command = cli.Command{
 		Name:        "consume",
 		Description: "Consumes a local directory and uploads each file to Paperless instance. The files will be deleted once uploaded.",
-		Before:      LogMetadata,
-		Action:      c.Action,
+		Action:      actions(LogMetadata, c.Action),
 
 		Flags: []cli.Flag{
 			newURLFlag(&c.PaperlessURL),

--- a/flags.go
+++ b/flags.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"fmt"
+
 	"github.com/urfave/cli/v2"
 )
 
@@ -17,6 +19,7 @@ func newURLFlag(dest *string) *cli.StringFlag {
 		Name: "url", EnvVars: envVars("URL"),
 		Usage:       "URL endpoint of the paperless instance.",
 		Required:    true,
+		Action:      checkEmptyString("url"),
 		Destination: dest,
 	}
 }
@@ -24,7 +27,9 @@ func newURLFlag(dest *string) *cli.StringFlag {
 func newTokenFlag(dest *string) *cli.StringFlag {
 	return &cli.StringFlag{
 		Name: "token", EnvVars: envVars("TOKEN"),
-		Usage:       "Password or Token of the paperless instance.",
+		Usage:       "password or token of the paperless instance.",
+		Required:    true,
+		Action:      checkEmptyString("token"),
 		Destination: dest,
 	}
 }
@@ -81,5 +86,17 @@ func newConsumeDirFlag(dest *string) *cli.StringFlag {
 		Usage:       "the directory name which to consume files.",
 		Required:    true,
 		Destination: dest,
+		Action:      checkEmptyString("consume-dir"),
+	}
+}
+
+func checkEmptyString(flagName string) func(*cli.Context, string) error {
+	return func(ctx *cli.Context, s string) error {
+		if s == "" {
+			ctx.Command.Subcommands = nil // required to print usage of subcommand
+			_ = cli.ShowCommandHelp(ctx, ctx.Command.Name)
+			return fmt.Errorf(`Required flag %q not set`, flagName)
+		}
+		return nil
 	}
 }

--- a/main.go
+++ b/main.go
@@ -62,3 +62,14 @@ func envVars(suffixes ...string) []string {
 	}
 	return arr
 }
+
+func actions(actions ...cli.ActionFunc) cli.ActionFunc {
+	return func(ctx *cli.Context) error {
+		for _, action := range actions {
+			if err := action(ctx); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+}


### PR DESCRIPTION
## Summary

* Fixes the command usage printing when a required flag is missing
* Disallows setting empty strings for required flags

## Checklist


- [x] Categorize the PR by setting a good title and adding one of the labels:
      `kind:bug`, `kind:enhancement`, `kind:documentation`, `kind:change`, `kind:breaking`, `kind:dependency`
      as they show up in the changelog
- [x] Link this PR to related issues
