### PR TITLE
Add flag to delete file after upload

### DIFF
--- a/flags.go
+++ b/flags.go
@@ -80,6 +80,14 @@ func newTagFlag(dest *cli.StringSlice) *cli.StringSliceFlag {
 	}
 }
 
+func newDeleteAfterUploadFlag(dest *bool) *cli.BoolFlag {
+	return &cli.BoolFlag{
+		Name: "delete-after-upload", EnvVars: envVars("DELETE_AFTER_UPLOAD"),
+		Usage:       "deletes the file(s) after upload",
+		Destination: dest,
+	}
+}
+
 func newConsumeDirFlag(dest *string) *cli.StringFlag {
 	return &cli.StringFlag{
 		Name: "consume-dir", EnvVars: []string{"CONSUME_DIR"},

--- a/upload_command.go
+++ b/upload_command.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/ccremer/clustercode/pkg/paperless"
 	"github.com/ccremer/plogr"
@@ -17,11 +18,12 @@ type UploadCommand struct {
 	PaperlessToken string
 	PaperlessUser  string
 
-	CreatedAt     cli.Timestamp
-	DocumentTitle string
-	DocumentType  string
-	Correspondent string
-	DocumentTags  cli.StringSlice
+	CreatedAt         cli.Timestamp
+	DocumentTitle     string
+	DocumentType      string
+	Correspondent     string
+	DocumentTags      cli.StringSlice
+	DeleteAfterUpload bool
 }
 
 func newUploadCommand() *UploadCommand {
@@ -48,6 +50,7 @@ func newUploadCommand() *UploadCommand {
 			newDocumentTypeFlag(&c.DocumentType),
 			newCorrespondentFlag(&c.Correspondent),
 			newTagFlag(&c.DocumentTags),
+			newDeleteAfterUploadFlag(&c.DeleteAfterUpload),
 		},
 		ArgsUsage: "[FILES...]",
 	}
@@ -78,6 +81,19 @@ func (c *UploadCommand) Action(ctx *cli.Context) error {
 		pterm.Success.Println(plogr.DefaultFormatter("File uploaded", map[string]interface{}{
 			"file": arg,
 		}))
+		if c.DeleteAfterUpload {
+			c.deleteAfterUpload(arg)
+		}
 	}
 	return nil
+}
+
+func (c *UploadCommand) deleteAfterUpload(arg string) {
+	err := os.Remove(arg)
+	if err != nil {
+		pterm.Warning.Println(plogr.DefaultFormatter("File could not be deleted", map[string]interface{}{
+			"file":  arg,
+			"error": err,
+		}))
+	}
 }


### PR DESCRIPTION
## Summary

* Adds `delete-after-upload` flag that deletes a file after successful upload.
* Useful for scripted use cases.

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `kind:bug`, `kind:enhancement`, `kind:documentation`, `kind:change`, `kind:breaking`, `kind:dependency`
      as they show up in the changelog
- [x] Link this PR to related issues

<!--
Remove the section and checklist items that do not apply.
For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
