### PR TITLE
Add make and docker-compose for local paperless instance

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,8 @@ include Makefile.vars.mk
 # Following includes do not print warnings or error if files aren't found
 # Optional Documentation module.
 -include docs/docs.mk
+# Optional local env module.
+-include test/local.mk
 
 .PHONY: help
 help: ## Show this help

--- a/README.md
+++ b/README.md
@@ -1,2 +1,22 @@
 # paperless-cli
 CLI tool to interact with paperless-ngx remote API
+
+
+## Development
+
+### Requirements
+
+- go
+- docker
+- docker-compose (if running local test instance of paperless-ngx)
+- goreleaser (if building deb/rpm packages locally)
+
+### Build
+
+Run `go run . --help` to directly invoke the CLI for testing purposes.
+Run `make help` to see a list of available targets.
+
+Commonly used:
+
+- `make build`: Build the project
+- `make local-install`: Start paperless-ngx in docker-compose (`http://localhost:8008`, user `admin:admin`)

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -1,0 +1,47 @@
+# docker-compose file for running paperless from the Docker Hub.
+# This file contains everything paperless needs to run.
+# Paperless supports amd64, arm and arm64 hardware.
+#
+# All compose files of paperless configure paperless in the following way:
+#
+# - Paperless is (re)started on system boot, if it was running before shutdown.
+# - Docker volumes for storing data are managed by Docker.
+# - Folders for importing and exporting files are created in the same directory
+#   as this file and mounted to the correct folders inside the container.
+# - Paperless listens on port 8000.
+#
+# SQLite is used as the database. The SQLite file is stored in the data volume.
+#
+# To install and update paperless with this file, do the following:
+#
+# - Copy this file as 'docker-compose.yml' and the files 'docker-compose.env'
+#   and '.env' into a folder.
+# - Run 'docker-compose pull'.
+# - Run 'docker-compose run --rm webserver createsuperuser' to create a user.
+# - Run 'docker-compose up -d'.
+#
+# For more extensive installation and update instructions, refer to the
+# documentation.
+
+version: "3.4"
+services:
+  broker:
+    image: docker.io/library/redis:7
+    restart: unless-stopped
+    volumes:
+      - redisdata:/data
+
+  webserver:
+    image: ghcr.io/paperless-ngx/paperless-ngx:latest
+    restart: unless-stopped
+    depends_on:
+      - broker
+    ports:
+      - "8008:8000"
+    environment:
+      PAPERLESS_REDIS: redis://broker:6379
+      PAPERLESS_ADMIN_USER: admin
+      PAPERLESS_ADMIN_PASSWORD: admin
+
+volumes:
+  redisdata:

--- a/test/local.mk
+++ b/test/local.mk
@@ -1,0 +1,12 @@
+compose_file = test/docker-compose.yml
+compose_project = paperless-cli
+
+clean_targets += local-uninstall
+
+.PHONY: local-install
+local-install: ## Install paperless-ngx in docker-compose
+	docker-compose -f $(compose_file) -p $(compose_project) up -d
+
+.PHONY: local-uninstall
+local-uninstall: ## Uninstall paperless-ngx in docker-compose
+	docker-compose -f $(compose_file) -p $(compose_project) rm --force --stop -v


### PR DESCRIPTION
## Summary

* Adds `make local-install` to install a non-persistent paperless instance on `http://localhost:8008`
* Requires `docker-compose`

## Checklist


- [x] Categorize the PR by setting a good title and adding one of the labels:
      `kind:bug`, `kind:enhancement`, `kind:documentation`, `kind:change`, `kind:breaking`, `kind:dependency`
      as they show up in the changelog
- [x] Link this PR to related issues

<!--
Remove the section and checklist items that do not apply.
For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
