### PR TITLE
Add armv7 builds

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -4,12 +4,13 @@ builds:
       - CGO_ENABLED=0 # this is needed otherwise the Docker image build is faulty
     goarch:
       - amd64
+      - arm
       - arm64
     goos:
       - linux
       - windows
     goarm:
-      - 8
+      - 7
 
 archives:
   - format: binary

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -54,6 +54,14 @@ dockers:
     image_templates:
       - "{{ .Env.CONTAINER_REGISTRY }}/{{ .Env.IMAGE_NAME }}:v{{ .Version }}-arm64"
 
+  - goarch: arm
+    goarm: 7
+    use: buildx
+    build_flag_templates:
+      - "--platform=linux/arm/v7"
+    image_templates:
+      - "{{ .Env.CONTAINER_REGISTRY }}/{{ .Env.IMAGE_NAME }}:v{{ .Version }}-armv7"
+
 docker_manifests:
   ## ghcr.io
   # For prereleases, updating `latest` does not make sense.
@@ -62,11 +70,13 @@ docker_manifests:
     image_templates:
       - "{{ .Env.CONTAINER_REGISTRY }}/{{ .Env.IMAGE_NAME }}:v{{ .Version }}-amd64"
       - "{{ .Env.CONTAINER_REGISTRY }}/{{ .Env.IMAGE_NAME }}:v{{ .Version }}-arm64"
+      - "{{ .Env.CONTAINER_REGISTRY }}/{{ .Env.IMAGE_NAME }}:v{{ .Version }}-armv7"
 
   - name_template: "{{ .Env.CONTAINER_REGISTRY }}/{{ .Env.IMAGE_NAME }}:v{{ .Version }}"
     image_templates:
       - "{{ .Env.CONTAINER_REGISTRY }}/{{ .Env.IMAGE_NAME }}:v{{ .Version }}-amd64"
       - "{{ .Env.CONTAINER_REGISTRY }}/{{ .Env.IMAGE_NAME }}:v{{ .Version }}-arm64"
+      - "{{ .Env.CONTAINER_REGISTRY }}/{{ .Env.IMAGE_NAME }}:v{{ .Version }}-armv7"
 
 release:
   prerelease: auto


### PR DESCRIPTION
## Summary

* Add armv7 builds
* GOARM is only used when GOARCH is set - 8 is not supportet / needed

For devices without proper arm64 support like older Raspberry Pi models.


